### PR TITLE
CI: Check data.json exists before deploying page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,13 +39,24 @@ jobs:
         GRAPHQL_TOKEN: ${{ secrets.GRAPHQL_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Check that data.json was created
+      id: check_data
+      run: |
+        if [ -f "out/data.json" ]; then
+          echo "exists=true" >> $GITHUB_OUTPUT
+        else
+          echo "exists=false" >> $GITHUB_OUTPUT
+        fi
+
     - name: Archive production artifacts
+      if: steps.check_data.outputs.exists == 'true'
       uses: actions/upload-artifact@v4
       with:
         name: web-static
         path: out
 
     - name: Deploy to GitHub Pages 🚀
+      if: steps.check_data.outputs.exists == 'true'
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         branch: gh-pages

--- a/out.log
+++ b/out.log
@@ -1,0 +1,1 @@
+exists=false


### PR DESCRIPTION
This might help workaround the issue we're having where the page is sometimes lacking any data.

This seems to happen when it fails like this:
https://github.com/godotengine/godot-team-reports/actions/runs/19669616567/job/56334940240

<img width="766" height="834" alt="image" src="https://github.com/user-attachments/assets/1b245969-7c38-45de-8400-689578df67e0" />

That's an issue we've fixed already in other GH fetchers and we should do it here too. node-fetch has a bug where it will sometimes just break but not return an error code, so the CI keeps going and uploads a broken site.